### PR TITLE
Added exception to Telegram as a User for BOT_PM

### DIFF
--- a/bot/modules/mirror.py
+++ b/bot/modules/mirror.py
@@ -403,7 +403,7 @@ class MirrorListener:
 
 def _mirror(bot, message, isZip=False, extract=False, isQbit=False, isLeech=False, pswd=None, multi=0):
     buttons = ButtonMaker()
-    if BOT_PM and message.chat.type != 'private':
+    if BOT_PM and message.chat.type != 'private' and message.from_user.id != 777000:
         try:
             msg1 = f'Added your Requested link to Download\n'
             send = bot.sendMessage(message.from_user.id, text=msg1)


### PR DESCRIPTION
Solves the case when BOT_PM is enabled and Bot tries to respond to RSS FEED post from a channel , it identifies the user as TELEGRAM (777000) and wont proceed as the PM is not possible