### PR TITLE
Added exception to Telegram as a User for BOT_PM in clone

### DIFF
--- a/bot/modules/clone.py
+++ b/bot/modules/clone.py
@@ -21,7 +21,7 @@ def _clone(message, bot, multi=0):
         reply_to = message.reply_to_message
         if reply_to is not None:
             reply_to.delete()
-    if BOT_PM:
+    if BOT_PM and message.from_user.id != 777000:
         try:
             msg1 = f'Added your Requested link to Download\n'
             send = bot.sendMessage(message.from_user.id, text=msg1)


### PR DESCRIPTION
Solves the case when BOT_PM is enabled and Bot tries to respond to RSS FEED post from a channel , it identifies the user as TELEGRAM (777000) and wont proceed as the PM is not possible