### PR TITLE
improvements h-code

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -366,6 +366,11 @@ try:
 except:
     AS_DOCUMENT = False
 try:
+    FILENAME_WITH_PATHS = getConfig('FILENAME_WITH_PATHS')
+    FILENAME_WITH_PATHS = FILENAME_WITH_PATHS.lower() == 'true'
+except:
+    FILENAME_WITH_PATHS = False
+try:
     EQUAL_SPLITS = getConfig('EQUAL_SPLITS')
     EQUAL_SPLITS = EQUAL_SPLITS.lower() == 'true'
 except:

--- a/bot/helper/mirror_utils/download_utils/yt_dlp_download_helper.py
+++ b/bot/helper/mirror_utils/download_utils/yt_dlp_download_helper.py
@@ -180,7 +180,7 @@ class YoutubeDLHelper:
         if self.__is_cancelled:
             return
         if self.is_playlist:
-            self.opts['outtmpl'] = f"{path}/{self.name}/%(title)s.%(ext)s"
+            self.opts['outtmpl'] = f"{path}/{self.name}/%(playlist_index)s.%(n_entries)s %(title)s.%(ext)s"
         elif args is None:
             self.opts['outtmpl'] = f"{path}/{self.name}"
         else:

--- a/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
+++ b/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
@@ -5,7 +5,7 @@ from pyrogram.errors import FloodWait, RPCError
 from PIL import Image
 from threading import RLock
 
-from bot import AS_DOCUMENT, AS_DOC_USERS, AS_MEDIA_USERS, CUSTOM_FILENAME, EXTENSION_FILTER, app, app_session, BOT_PM, LEECH_LOG
+from bot import AS_DOCUMENT, AS_DOC_USERS, AS_MEDIA_USERS, CUSTOM_FILENAME, EXTENSION_FILTER, app, app_session, BOT_PM, LEECH_LOG, FILENAME_WITH_PATHS
 from bot.helper.ext_utils.fs_utils import take_ss, get_media_info, get_media_streams, clean_unwanted
 from bot.helper.ext_utils.bot_utils import get_readable_file_size
 
@@ -85,14 +85,25 @@ class TgUploader:
             LEECH_DUMP = int(setstr)
             leechchat = LEECH_DUMP
         else: leechchat = self.__listener.message.chat.id
+        # print full path file location +
+        if FILENAME_WITH_PATHS:
+            keption = DOWNLOAD_DIR
+            if not keption.endswith('/'): keption = keption + '/'
+            if not keption.startswith('/'): keption = '/' + keption
+            keption = up_path.replace(keption, '', 1)
+            zoy = keption.split('/')[0]
+            keption = keption.replace(zoy, '', 1)
+            if keption.startswith('/'): keption = keption.replace('/', '', 1)
+        else: keption = None
+        # print full path file location -
         if CUSTOM_FILENAME is not None:
-            cap_mono = f"{CUSTOM_FILENAME} <b>{file_}</b>"
+            cap_mono = f"{CUSTOM_FILENAME} <b>{keption or file_}</b>"
             file_ = f"{CUSTOM_FILENAME} {file_}"
             new_path = ospath.join(dirpath, file_)
             osrename(up_path, new_path)
             up_path = new_path
         else:
-            cap_mono = f"<b>{file_}</b>"
+            cap_mono = f"<b>{keption or file_}</b>"
         notMedia = False
         thumb = self.__thumb
         self.__is_corrupted = False

--- a/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
+++ b/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
@@ -5,7 +5,7 @@ from pyrogram.errors import FloodWait, RPCError
 from PIL import Image
 from threading import RLock
 
-from bot import AS_DOCUMENT, AS_DOC_USERS, AS_MEDIA_USERS, CUSTOM_FILENAME, EXTENSION_FILTER, app, app_session, BOT_PM, LEECH_LOG, FILENAME_WITH_PATHS
+from bot import AS_DOCUMENT, AS_DOC_USERS, AS_MEDIA_USERS, CUSTOM_FILENAME, EXTENSION_FILTER, app, app_session, BOT_PM, LEECH_LOG, FILENAME_WITH_PATHS, DOWNLOAD_DIR
 from bot.helper.ext_utils.fs_utils import take_ss, get_media_info, get_media_streams, clean_unwanted
 from bot.helper.ext_utils.bot_utils import get_readable_file_size
 

--- a/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
+++ b/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
@@ -97,13 +97,13 @@ class TgUploader:
         else: keption = None
         # print full path file location -
         if CUSTOM_FILENAME is not None:
-            cap_mono = f"{CUSTOM_FILENAME} <b>{keption or file_}</b>"
+            cap_mono = f"<code>{CUSTOM_FILENAME} {keption or file_}</code>"
             file_ = f"{CUSTOM_FILENAME} {file_}"
             new_path = ospath.join(dirpath, file_)
             osrename(up_path, new_path)
             up_path = new_path
         else:
-            cap_mono = f"<b>{keption or file_}</b>"
+            cap_mono = f"<code>{keption or file_}</code>"
         notMedia = False
         thumb = self.__thumb
         self.__is_corrupted = False

--- a/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
+++ b/bot/helper/mirror_utils/upload_utils/pyrogramEngine.py
@@ -138,7 +138,7 @@ class TgUploader:
                                                                   supports_streaming=True,
                                                                   disable_notification=True,
                                                                   progress=self.__upload_progress)
-                    if not self.isPrivate and BOT_PM:
+                    if BOT_PM:
                         try:
                             app.copy_message(chat_id=self.__user_id, from_chat_id=self.__sent_msg.chat.id, message_id=self.__sent_msg.id)
                         except Exception as err:
@@ -153,7 +153,7 @@ class TgUploader:
                                                                   thumb=thumb,
                                                                   disable_notification=True,
                                                                   progress=self.__upload_progress)
-                    if not self.isPrivate and BOT_PM:
+                    if BOT_PM:
                         try:
                             app.copy_message(chat_id=self.__user_id, from_chat_id=self.__sent_msg.chat.id, message_id=self.__sent_msg.id)
                         except Exception as err:
@@ -163,7 +163,7 @@ class TgUploader:
                                                                   caption=cap_mono,
                                                                   disable_notification=True,
                                                                   progress=self.__upload_progress)
-                    if not self.isPrivate and BOT_PM:
+                    if BOT_PM:
                         try:
                             app.copy_message(chat_id=self.__user_id, from_chat_id=self.__sent_msg.chat.id, message_id=self.__sent_msg.id)
                         except Exception as err:
@@ -182,7 +182,7 @@ class TgUploader:
                                                                  caption=cap_mono,
                                                                  disable_notification=True,
                                                                  progress=self.__upload_progress)
-                if not self.isPrivate and BOT_PM:
+                if BOT_PM:
                     try:
                         app.copy_message(chat_id=self.__user_id, from_chat_id=self.__sent_msg.chat.id, message_id=self.__sent_msg.id)
                     except Exception as err:


### PR DESCRIPTION
- FILENAME_WITH_PATHS Default false. Send files along with their directory names. Useful for archives. Example:
![image](https://user-images.githubusercontent.com/111054559/192860004-b4276156-a6bc-4e7e-94bf-2a296326c905.png)

-  ytdl playlists will download with playlist indexes. Example:
![image](https://user-images.githubusercontent.com/111054559/192857954-9675e13c-6562-4616-aa28-6e50ea37cafe.png)

- fix #135
- copyable filenames
